### PR TITLE
Metadata to get region 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/pkg/errors v0.9.1
 	github.com/vultr/govultr v0.3.1
+	github.com/vultr/metadata v1.0.0
 	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -508,6 +508,10 @@ github.com/vultr/govultr v0.3.1-0.20200310123756-4d7aa752283f h1:tP/QFmgk57SVGwv
 github.com/vultr/govultr v0.3.1-0.20200310123756-4d7aa752283f/go.mod h1:81RwK1wAmb08alkFDJiZmu9gdv+IO+UamzaF0+PIieE=
 github.com/vultr/govultr v0.3.1 h1:r0JPvWUSGmRAHEhevtpJS+j+7DdK+m8xyvGkZlIc2XA=
 github.com/vultr/govultr v0.3.1/go.mod h1:81RwK1wAmb08alkFDJiZmu9gdv+IO+UamzaF0+PIieE=
+github.com/vultr/metadata v0.1.0 h1:coaBWynp2ShS6ioPx9Ht+DRX8NYYWF7z9IgOGHSDG08=
+github.com/vultr/metadata v0.1.0/go.mod h1:jrwOrwAtk+Gu8LdtQqKhks+qf6RSt7SHImAdPwSt30c=
+github.com/vultr/metadata v1.0.0 h1:xcgaix3ztcIgFFBFIeva9fbYby5NZlnsjTCja+nx8mo=
+github.com/vultr/metadata v1.0.0/go.mod h1:jrwOrwAtk+Gu8LdtQqKhks+qf6RSt7SHImAdPwSt30c=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/vendor/github.com/go-openapi/swag/go.mod
+++ b/vendor/github.com/go-openapi/swag/go.mod
@@ -1,7 +1,5 @@
 module github.com/go-openapi/swag
 
-go 1.14
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect

--- a/vendor/github.com/google/uuid/go.mod
+++ b/vendor/github.com/google/uuid/go.mod
@@ -1,3 +1,1 @@
 module github.com/google/uuid
-
-go 1.14

--- a/vendor/github.com/hashicorp/go-cleanhttp/go.mod
+++ b/vendor/github.com/hashicorp/go-cleanhttp/go.mod
@@ -1,3 +1,1 @@
 module github.com/hashicorp/go-cleanhttp
-
-go 1.14

--- a/vendor/github.com/hashicorp/golang-lru/go.mod
+++ b/vendor/github.com/hashicorp/golang-lru/go.mod
@@ -1,3 +1,1 @@
 module github.com/hashicorp/golang-lru
-
-go 1.14

--- a/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
+++ b/vendor/github.com/konsorten/go-windows-terminal-sequences/go.mod
@@ -1,3 +1,1 @@
 module github.com/konsorten/go-windows-terminal-sequences
-
-go 1.14

--- a/vendor/github.com/prometheus/procfs/go.mod
+++ b/vendor/github.com/prometheus/procfs/go.mod
@@ -1,5 +1,3 @@
 module github.com/prometheus/procfs
 
-go 1.14
-
 require golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4

--- a/vendor/github.com/sirupsen/logrus/go.mod
+++ b/vendor/github.com/sirupsen/logrus/go.mod
@@ -1,7 +1,5 @@
 module github.com/sirupsen/logrus
 
-go 1.14
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1

--- a/vendor/github.com/vultr/metadata/.gitignore
+++ b/vendor/github.com/vultr/metadata/.gitignore
@@ -1,0 +1,22 @@
+### Go ###
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+### Go Patch ###
+/vendor/
+/Godeps/
+
+.idea/

--- a/vendor/github.com/vultr/metadata/LICENSE
+++ b/vendor/github.com/vultr/metadata/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Vultr
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/vultr/metadata/README.md
+++ b/vendor/github.com/vultr/metadata/README.md
@@ -1,0 +1,23 @@
+# metadata
+
+A Go client that interacts with the [Vultr Metadata](https://www.vultr.com/metadata/).
+
+## Installation
+
+`go get -u github.com/vultr/metadata`
+
+## Usage
+
+Currently, there is only one available call `Metadata()` which will retrieve your entire metadata from your instance. If you want to retrieve a specific of your metadata you can do so by calling the corresponding exported field on the `metadata` struct.
+
+```go
+c := metadata.NewClient()
+
+meta, err := c.Metadata()
+if err != nil {
+	fmt.Println(err)
+}
+
+fmt.Println(meta)
+fmt.Println(meta.InstanceID) // will print your instance-id
+```

--- a/vendor/github.com/vultr/metadata/client.go
+++ b/vendor/github.com/vultr/metadata/client.go
@@ -1,0 +1,106 @@
+package metadata
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+const (
+	timeout  = 3 * time.Second
+	basePath = "http://169.254.169.254"
+)
+
+type Client struct {
+	client  *http.Client
+	baseUrl *url.URL
+}
+
+func NewClient() *Client {
+
+	u, err := url.Parse(basePath)
+	if err != nil {
+		panic(err)
+	}
+
+	c := &Client{
+		client: &http.Client{
+			Timeout: timeout,
+		},
+		baseUrl: u,
+	}
+
+	return c
+}
+
+// Metadata returns the entire contents of the instances metadata
+func (c *Client) Metadata() (*MetaData, error) {
+	metadata := &MetaData{}
+
+	err := c.doRequest("/v1.json", metadata)
+	if err != nil {
+		return nil, err
+	}
+
+	return metadata, nil
+}
+
+func (c *Client) doRequest(uri string, meta *MetaData) error {
+
+	resp, err := c.client.Get(fmt.Sprintf("%s%s", c.baseUrl, uri))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode == http.StatusOK {
+		if err := json.Unmarshal(body, meta); err != nil {
+			return err
+		}
+	} else {
+		return fmt.Errorf("error : %s", string(body))
+	}
+
+	return nil
+}
+
+func (c *Client) SetBaseURL(baseUrl string) error {
+	updatedURL, err := url.Parse(baseUrl)
+	if err != nil {
+		return err
+	}
+
+	c.baseUrl = updatedURL
+	return nil
+}
+
+// RegionCodeToID takes in a region code and returns back the region ID
+func RegionCodeToID(code string) string {
+	regions := map[string]string{
+		"EWR": "1",
+		"ORD": "2",
+		"DFW": "3",
+		"SEA": "4",
+		"LAX": "5",
+		"ATL": "6",
+		"AMS": "7",
+		"LHR": "8",
+		"FRA": "9",
+		"SJC": "12",
+		"SYD": "19",
+		"YTO": "22",
+		"CDG": "24",
+		"NRT": "25",
+		"MIA": "39",
+		"SGP": "40",
+	}
+
+	return regions[code]
+}

--- a/vendor/github.com/vultr/metadata/go.mod
+++ b/vendor/github.com/vultr/metadata/go.mod
@@ -1,0 +1,3 @@
+module github.com/vultr/metadata
+
+go 1.14

--- a/vendor/github.com/vultr/metadata/metadata_json.go
+++ b/vendor/github.com/vultr/metadata/metadata_json.go
@@ -1,0 +1,50 @@
+package metadata
+
+type MetaData struct {
+	Hostname   string `json:"hostname,omitempty"`
+	InstanceID string `json:"instanceid,omitempty"`
+	PublicKeys string `json:"public-keys,omitempty"`
+
+	Region struct {
+		RegionCode string `json:"regioncode,omitempty"`
+	} `json:"region,omitempty"`
+
+	BGP struct {
+		IPv4 struct {
+			MyAddress   string `json:"my-address,omitempty"`
+			MyASN       string `json:"my-asn,omitempty"`
+			PeerAddress string `json:"peer-address,omitempty"`
+			PeerASN     string `json:"peer-asn,omitempty"`
+		} `json:"ipv4,omitempty"`
+		IPv6 struct {
+			MyAddress   string `json:"my-address,omitempty"`
+			MyASN       string `json:"my-asn,omitempty"`
+			PeerAddress string `json:"peer-address,omitempty"`
+			PeerASN     string `json:"peer-asn,omitempty"`
+		} `json:"ipv6,omitempty"`
+	} `json:"bgp,omitempty"`
+
+	Interfaces []struct {
+		IPv4 struct {
+			Additional []struct {
+				Address string `json:"address,omitempty"`
+				Netmask string `json:"netmask,omitempty"`
+			}
+			Address string `json:"address,omitempty"`
+			Gateway string `json:"gateway,omitempty"`
+			Netmask string `json:"netmask,omitempty"`
+		} `json:"ipv4,omitempty"`
+		IPv6 struct {
+			Additional []struct {
+				Address string `json:"address,omitempty"`
+				Prefix  string `json:"prefix,omitempty"`
+			}
+			Address string `json:"address,omitempty"`
+			Gateway string `json:"gateway,omitempty"`
+			Prefix  string `json:"prefix,omitempty"`
+		} `json:"ipv6,omitempty"`
+		Mac         string `json:"mac,omitempty"`
+		NetworkType string `json:"network-type,omitempty"`
+		NetworkID   string `json:"networkid,omitempty"`
+	} `json:"interfaces,omitempty"`
+}

--- a/vendor/google.golang.org/grpc/go.mod
+++ b/vendor/google.golang.org/grpc/go.mod
@@ -1,7 +1,5 @@
 module google.golang.org/grpc
 
-go 1.14
-
 require (
 	cloud.google.com/go v0.26.0 // indirect
 	github.com/BurntSushi/toml v0.3.1 // indirect

--- a/vendor/gopkg.in/yaml.v2/go.mod
+++ b/vendor/gopkg.in/yaml.v2/go.mod
@@ -1,5 +1,5 @@
-module gopkg.in/yaml.v2
+module "gopkg.in/yaml.v2"
 
-go 1.14
-
-require gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
+require (
+	"gopkg.in/check.v1" v0.0.0-20161208181325-20d25e280405
+)

--- a/vendor/gopkg.in/yaml.v2/go.sum
+++ b/vendor/gopkg.in/yaml.v2/go.sum
@@ -1,1 +1,0 @@
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -118,6 +118,8 @@ github.com/spf13/cobra
 github.com/spf13/pflag
 # github.com/vultr/govultr v0.3.1
 github.com/vultr/govultr
+# github.com/vultr/metadata v1.0.0
+github.com/vultr/metadata
 # go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738
 go.etcd.io/etcd/auth/authpb
 go.etcd.io/etcd/clientv3


### PR DESCRIPTION
## Description
The CCM will now make a call to the metadata on the instance to get its region.

Deployed a test cluster to and verified that CCM continues to operate as expected and gets metadata region info.

```
Containers:
  vultr-cloud-controller-manager:
    Container ID:  docker://113763a50ed651d1261c5e2451f7de3d3b2dc585968f7c186418f961bb55eaca
    Image:         ddymko/vultr-cloud-controller-manager:v0.0.3
    Image ID:      docker-pullable://ddymko/vultr-cloud-controller-manager@sha256:91abc2f8232f5c3b7b42903e778d1ba244d8098db30c9ad72d4766f9bc18fda9
    Port:          <none>
    Host Port:     <none>
    Command:
      /vultr-cloud-controller-manager
      --cloud-provider=vultr
      --allow-untagged-cloud=true
      --authentication-skip-lookup=true
      --v=3
    State:          Running
      Started:      Thu, 30 Apr 2020 09:28:26 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      VULTR_API_KEY:  <set to the key 'api-key' in secret 'vultr-ccm'>  Optional: false
    Mounts:
      /var/run/secrets/kubernetes.io/serviceaccount from vultr-ccm-token-zrzfr (ro)
```

In the release ticket I'll make a note in the secret.yml.tmp that `region` isn't required as of v0.0.3

## Related Issues

### Checklist:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you linted your code locally prior to submission?
* [x] Have you successfully ran tests with your changes locally?
