### PR TITLE
Support non vpc vm instances

### DIFF
--- a/vultr/instancesv2.go
+++ b/vultr/instancesv2.go
@@ -167,32 +167,47 @@ func (i *instancesv2) InstanceMetadata(ctx context.Context, node *v1.Node) (*clo
 
 // nodeInstanceAddresses gathers public/private IP addresses and returns a []v1.NodeAddress .
 func (i *instancesv2) nodeInstanceAddresses(instance *govultr.Instance) ([]v1.NodeAddress, error) {
-	var addresses []v1.NodeAddress
+        var addresses []v1.NodeAddress
 
-	if reflect.DeepEqual(instance, *&govultr.Instance{}) { //nolint
-		return nil, fmt.Errorf("instance is empty %v", instance)
-	}
+        if reflect.DeepEqual(instance, *&govultr.Instance{}) { //nolint
+                return nil, fmt.Errorf("instance is empty %v", instance)
+        }
 
-	addresses = append(addresses, v1.NodeAddress{
-		Type:    v1.NodeHostName,
-		Address: instance.Label,
-	})
+        addresses = append(addresses, v1.NodeAddress{
+                Type:    v1.NodeHostName,
+                Address: instance.Label,
+        })
 
-	// make sure we have either pubic and private ip
-	if instance.InternalIP == "" || instance.MainIP == "" {
-		return nil, fmt.Errorf("require both public and private IP")
-	}
+        // Check conditions for internal and main IP
+        if instance.InternalIP == "" && instance.MainIP == "" {
+                return nil, fmt.Errorf("require at least one of internal or public IP")
+        }
 
-	addresses = append(addresses,
-		v1.NodeAddress{Type: v1.NodeInternalIP, Address: instance.InternalIP}, // private IP
-		v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.MainIP},     // public IP
-	)
+        // Handle the case where both IPs are provided
+        if instance.InternalIP != "" && instance.MainIP != "" {
+                addresses = append(addresses,
+                        v1.NodeAddress{Type: v1.NodeInternalIP, Address: instance.InternalIP}, // private IP
+                        v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.MainIP},     // public IP
+                )
+        } else if instance.InternalIP == "" && instance.MainIP != "" {
+                // If internal IP is empty but main IP is not, use main IP for both
+                addresses = append(addresses,
+                        v1.NodeAddress{Type: v1.NodeInternalIP, Address: instance.MainIP}, // treat main IP as internal IP
+                        v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.MainIP}, // public IP
+                )
+        } else if instance.InternalIP != "" && instance.MainIP == "" {
+                // If main IP is empty but internal IP is not, use internal IP for both
+                addresses = append(addresses,
+                        v1.NodeAddress{Type: v1.NodeInternalIP, Address: instance.InternalIP}, // private IP
+                        v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.InternalIP}, // treat internal IP as external IP
+                )
+        }
 
-	if instance.V6MainIP != "" {
-		addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.V6MainIP}) // IPv6
-	}
+        if instance.V6MainIP != "" {
+                addresses = append(addresses, v1.NodeAddress{Type: v1.NodeExternalIP, Address: instance.V6MainIP}) // IPv6
+        }
 
-	return addresses, nil
+        return addresses, nil
 }
 
 // getVultrInstance attempts to obtain Vultr Instance from Vultr API


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Description
<!-- Write a brief description of the changes introduced by this PR -->
This PR adds support for non VPC VM instances by changing the logic for looking up IP addresses to not require having an internal IP returned from the API as that field is empty in non VPC instances.

## Related Issues
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234, Addresses #1234, Related to #1234, etc.
-->
Fixes #293 
### Checklist:

* [v] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [v] Have you linted your code locally prior to submission?
* [v] Have you successfully ran tests with your changes locally?
