### PR TITLE
add multi-service support

### DIFF
--- a/vultr/fakeclient.go
+++ b/vultr/fakeclient.go
@@ -241,11 +241,23 @@ func (f *FakeInstance) GetUpgrades(_ context.Context, _ string) (*govultr.Upgrad
 
 type fakeLB struct {
 	client *govultr.Client
+
+	forwardingRules []govultr.ForwardingRule
+	createdRules    []govultr.ForwardingRule
+	deletedRules    []string
+	updatedReq      *govultr.LoadBalancerReq
+	deletedLB       bool
 }
 
 // Create creates loadbalancer
 func (f *fakeLB) Create(_ context.Context, _ *govultr.LoadBalancerReq) (*govultr.LoadBalancer, *http.Response, error) {
-	panic("implement me")
+	return &govultr.LoadBalancer{
+		ID:     "6334f227-6d96-4cbd-9bcb-5be0759354fa",
+		Region: "ewr",
+		Label:  "albname",
+		Status: "active",
+		IPV4:   "192.168.0.1",
+	}, nil, nil
 }
 
 // Get gets loadbalancer
@@ -261,13 +273,15 @@ func (f *fakeLB) Get(_ context.Context, _ string) (*govultr.LoadBalancer, *http.
 }
 
 // Update updates loadbalancer
-func (f *fakeLB) Update(_ context.Context, _ string, _ *govultr.LoadBalancerReq) error {
+func (f *fakeLB) Update(_ context.Context, _ string, req *govultr.LoadBalancerReq) error {
+	f.updatedReq = req
 	return nil
 }
 
 // Delete deletes loadbalancer
 func (f *fakeLB) Delete(_ context.Context, _ string) error {
-	panic("implement me")
+	f.deletedLB = true
+	return nil
 }
 
 // DeleteAutoSSL deletes AutoSSL (not implemented, yet)
@@ -300,8 +314,9 @@ func (f *fakeLB) List(_ context.Context, _ *govultr.ListOptions) ([]govultr.Load
 }
 
 // CreateForwardingRule adds forwarding rule
-func (f *fakeLB) CreateForwardingRule(_ context.Context, _ string, _ *govultr.ForwardingRule) (*govultr.ForwardingRule, *http.Response, error) {
-	panic("implement me")
+func (f *fakeLB) CreateForwardingRule(_ context.Context, _ string, rule *govultr.ForwardingRule) (*govultr.ForwardingRule, *http.Response, error) {
+	f.createdRules = append(f.createdRules, *rule)
+	return rule, nil, nil
 }
 
 // GetForwardingRule returns forwarding rule
@@ -310,12 +325,23 @@ func (f *fakeLB) GetForwardingRule(_ context.Context, _, _ string) (*govultr.For
 }
 
 // DeleteForwardingRule deletes forwarding rule
-func (f *fakeLB) DeleteForwardingRule(_ context.Context, _, _ string) error {
-	panic("implement me")
+func (f *fakeLB) DeleteForwardingRule(_ context.Context, _, ruleID string) error {
+	f.deletedRules = append(f.deletedRules, ruleID)
+	return nil
 }
 
 // ListForwardingRules gets forwarding rules
 func (f *fakeLB) ListForwardingRules(_ context.Context, _ string, _ *govultr.ListOptions) ([]govultr.ForwardingRule, *govultr.Meta, *http.Response, error) {
+	if f.forwardingRules != nil {
+		return f.forwardingRules, &govultr.Meta{
+			Total: len(f.forwardingRules),
+			Links: &govultr.Links{
+				Next: "",
+				Prev: "",
+			},
+		}, nil, nil
+	}
+
 	return []govultr.ForwardingRule{{
 			RuleID:           "1234",
 			FrontendProtocol: "tcp",

--- a/vultr/loadbalancer_test.go
+++ b/vultr/loadbalancer_test.go
@@ -5,8 +5,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/vultr/govultr/v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -234,4 +236,231 @@ func TestLoadbalancers_EnsureLoadBalancerDeleted(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected nil got %s", err.Error())
 	}
+}
+
+func TestLoadbalancers_UpdateLoadBalancer_SharedLabelMergesForwardingRules(t *testing.T) {
+	for _, tc := range []struct {
+		name             string
+		annotations      map[string]string
+		frontendProtocol string
+		backendProtocol  string
+		existingRuleID   string
+		existingFrontend int
+		existingBackend  int
+		desiredFrontend  int32
+		desiredBackend   int32
+	}{
+		{
+			name:             "tcp",
+			annotations:      map[string]string{annoVultrLBProtocol: protocolTCP},
+			frontendProtocol: protocolTCP,
+			backendProtocol:  protocolTCP,
+			existingRuleID:   "rule-50001",
+			existingFrontend: 50001,
+			existingBackend:  30001,
+			desiredFrontend:  50002,
+			desiredBackend:   30002,
+		},
+		{
+			name:             "udp",
+			annotations:      map[string]string{annoVultrLBProtocol: protocolUDP},
+			frontendProtocol: protocolUDP,
+			backendProtocol:  protocolUDP,
+			existingRuleID:   "rule-50001",
+			existingFrontend: 50001,
+			existingBackend:  30001,
+			desiredFrontend:  50002,
+			desiredBackend:   30002,
+		},
+		{
+			name:             "http",
+			annotations:      map[string]string{annoVultrLBProtocol: protocolHTTP},
+			frontendProtocol: protocolHTTP,
+			backendProtocol:  protocolHTTP,
+			existingRuleID:   "rule-80",
+			existingFrontend: 80,
+			existingBackend:  30080,
+			desiredFrontend:  8080,
+			desiredBackend:   30081,
+		},
+		{
+			name: protocolHTTPS,
+			annotations: map[string]string{
+				annoVultrLBProtocol:   protocolHTTP,
+				annoVultrLBHTTPSPorts: "8443",
+			},
+			frontendProtocol: protocolHTTPS,
+			backendProtocol:  protocolHTTPS,
+			existingRuleID:   "rule-443",
+			existingFrontend: 443,
+			existingBackend:  30443,
+			desiredFrontend:  8443,
+			desiredBackend:   30444,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testSharedLabelMergeForwardingRules(t, tc.annotations, govultr.ForwardingRule{
+				RuleID:           tc.existingRuleID,
+				FrontendProtocol: tc.frontendProtocol,
+				FrontendPort:     tc.existingFrontend,
+				BackendProtocol:  tc.backendProtocol,
+				BackendPort:      tc.existingBackend,
+			}, govultr.ForwardingRule{
+				FrontendProtocol: tc.frontendProtocol,
+				FrontendPort:     int(tc.desiredFrontend),
+				BackendProtocol:  tc.backendProtocol,
+				BackendPort:      int(tc.desiredBackend),
+			}, tc.desiredFrontend, tc.desiredBackend)
+		})
+	}
+}
+
+func testSharedLabelMergeForwardingRules(t *testing.T, annotations map[string]string, existingRule, expectedRule govultr.ForwardingRule, port, nodePort int32) {
+	t.Helper()
+
+	fakeLoadBalancer := &fakeLB{
+		forwardingRules: []govultr.ForwardingRule{existingRule},
+	}
+	lb := &loadbalancers{
+		client: &govultr.Client{LoadBalancer: fakeLoadBalancer},
+		zone:   "ewr",
+	}
+	svcAnnotations := map[string]string{
+		annoVultrLoadBalancerID:    "6334f227-6d96-4cbd-9bcb-5be0759354fa",
+		annoVultrLoadBalancerLabel: "shared-load-balancer",
+	}
+	for key, value := range annotations {
+		svcAnnotations[key] = value
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "shared-service-b",
+			Namespace:   v1.NamespaceDefault,
+			UID:         "shared-service-b",
+			Annotations: svcAnnotations,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "service-port",
+					Port:     port,
+					NodePort: nodePort,
+				},
+			},
+		},
+	}
+
+	err := lb.UpdateLoadBalancer(context.Background(), "cluster-name", svc, nil)
+	if err != nil {
+		t.Fatalf("expected nil got %s", err.Error())
+	}
+
+	if fakeLoadBalancer.updatedReq == nil {
+		t.Fatal("expected load balancer update request")
+	}
+	if fakeLoadBalancer.updatedReq.ForwardingRules != nil {
+		t.Fatalf("expected shared load balancer update to omit forwarding rules, got %+v", fakeLoadBalancer.updatedReq.ForwardingRules)
+	}
+	if len(fakeLoadBalancer.deletedRules) != 0 {
+		t.Fatalf("expected no forwarding rule deletions, got %+v", fakeLoadBalancer.deletedRules)
+	}
+	if len(fakeLoadBalancer.createdRules) != 1 {
+		t.Fatalf("expected one created forwarding rule, got %+v", fakeLoadBalancer.createdRules)
+	}
+
+	createdRule := fakeLoadBalancer.createdRules[0]
+	if !forwardingRulesEqual(createdRule, expectedRule) {
+		t.Fatalf("unexpected created forwarding rule: %+v", createdRule)
+	}
+}
+
+func TestLoadbalancers_EnsureLoadBalancerDeleted_SharedLabelRemovesOnlyServiceRules(t *testing.T) {
+	fakeLoadBalancer := &fakeLB{
+		forwardingRules: []govultr.ForwardingRule{
+			{
+				RuleID:           "rule-50001",
+				FrontendProtocol: protocolUDP,
+				FrontendPort:     50001,
+				BackendProtocol:  protocolUDP,
+				BackendPort:      30001,
+			},
+			{
+				RuleID:           "rule-50002",
+				FrontendProtocol: protocolUDP,
+				FrontendPort:     50002,
+				BackendProtocol:  protocolUDP,
+				BackendPort:      30002,
+			},
+		},
+	}
+	lb := &loadbalancers{
+		client:     &govultr.Client{LoadBalancer: fakeLoadBalancer},
+		zone:       "ewr",
+		kubeClient: fake.NewClientset(sharedLabelService("shared-service-b", "shared-service-b", 50002, 30002)),
+	}
+
+	deletingService := sharedLabelService("shared-service-a", "shared-service-a", 50001, 30001)
+	err := lb.EnsureLoadBalancerDeleted(context.Background(), "cluster-name", deletingService)
+	if err != nil {
+		t.Fatalf("expected nil got %s", err.Error())
+	}
+
+	if fakeLoadBalancer.deletedLB {
+		t.Fatal("expected shared load balancer to remain while another service references its label")
+	}
+	if !reflect.DeepEqual(fakeLoadBalancer.deletedRules, []string{"rule-50001"}) {
+		t.Fatalf("expected only deleting service rule to be removed, got %+v", fakeLoadBalancer.deletedRules)
+	}
+}
+
+func TestLoadbalancers_EnsureLoadBalancerDeleted_SharedLabelDeletesLBWhenLastReference(t *testing.T) {
+	fakeLoadBalancer := &fakeLB{}
+	lb := &loadbalancers{
+		client:     &govultr.Client{LoadBalancer: fakeLoadBalancer},
+		zone:       "ewr",
+		kubeClient: fake.NewClientset(),
+	}
+
+	deletingService := sharedLabelService("shared-service-a", "shared-service-a", 50001, 30001)
+	err := lb.EnsureLoadBalancerDeleted(context.Background(), "cluster-name", deletingService)
+	if err != nil {
+		t.Fatalf("expected nil got %s", err.Error())
+	}
+
+	if !fakeLoadBalancer.deletedLB {
+		t.Fatal("expected shared load balancer to be deleted after last service reference is removed")
+	}
+	if len(fakeLoadBalancer.deletedRules) != 0 {
+		t.Fatalf("expected no forwarding rule deletions when deleting the load balancer, got %+v", fakeLoadBalancer.deletedRules)
+	}
+}
+
+func sharedLabelService(name, uid string, port, nodePort int32) *v1.Service {
+	return &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: v1.NamespaceDefault,
+			UID:       typesUID(uid),
+			Annotations: map[string]string{
+				annoVultrLoadBalancerID:    "6334f227-6d96-4cbd-9bcb-5be0759354fa",
+				annoVultrLoadBalancerLabel: "shared-load-balancer",
+				annoVultrLBProtocol:        protocolUDP,
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "service-port",
+					Protocol: v1.ProtocolUDP,
+					Port:     port,
+					NodePort: nodePort,
+				},
+			},
+		},
+	}
+}
+
+func typesUID(uid string) types.UID {
+	return types.UID(uid)
 }

--- a/vultr/loadbalancers.go
+++ b/vultr/loadbalancers.go
@@ -285,9 +285,19 @@ func (l *loadbalancers) updateLoadBalancerWithLB(ctx context.Context, _ string, 
 	if err != nil {
 		return fmt.Errorf("failed to create load balancer request: %s", err)
 	}
+	sharedLB := hasSharedLoadBalancerLabel(service)
+	if sharedLB {
+		lbReq.ForwardingRules = nil
+	}
 
 	if err := l.client.LoadBalancer.Update(ctx, lb.ID, lbReq); err != nil {
 		return fmt.Errorf("failed to update LB: %s", err)
+	}
+
+	if sharedLB {
+		if err := l.reconcileSharedForwardingRules(ctx, lb.ID, service); err != nil {
+			return fmt.Errorf("failed to reconcile shared LB forwarding rules: %s", err)
+		}
 	}
 
 	return nil
@@ -302,12 +312,170 @@ func (l *loadbalancers) EnsureLoadBalancerDeleted(ctx context.Context, _ string,
 		return err
 	}
 
+	if hasSharedLoadBalancerLabel(service) {
+		referenced, referenceErr := l.sharedLoadBalancerStillReferenced(ctx, service, lb.ID)
+		if referenceErr != nil {
+			return referenceErr
+		}
+
+		if referenced {
+			return l.deleteServiceForwardingRules(ctx, lb.ID, service)
+		}
+	}
+
 	err = l.client.LoadBalancer.Delete(ctx, lb.ID)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+func hasSharedLoadBalancerLabel(service *v1.Service) bool {
+	label, ok := service.Annotations[annoVultrLoadBalancerLabel]
+	return ok && label != ""
+}
+
+func (l *loadbalancers) reconcileSharedForwardingRules(ctx context.Context, lbID string, service *v1.Service) error {
+	desiredRules, err := buildForwardingRules(service)
+	if err != nil {
+		return err
+	}
+
+	existingRules, err := l.listForwardingRules(ctx, lbID)
+	if err != nil {
+		return err
+	}
+
+	existingByFrontend := map[string]govultr.ForwardingRule{}
+	for _, rule := range existingRules {
+		existingByFrontend[forwardingRuleFrontendKey(rule)] = rule
+	}
+
+	for _, desired := range desiredRules {
+		existing, ok := existingByFrontend[forwardingRuleFrontendKey(desired)]
+		if !ok {
+			if _, _, err := l.client.LoadBalancer.CreateForwardingRule(ctx, lbID, &desired); err != nil { //nolint:bodyclose
+				return err
+			}
+			continue
+		}
+
+		if forwardingRulesEqual(existing, desired) {
+			continue
+		}
+
+		if err := l.client.LoadBalancer.DeleteForwardingRule(ctx, lbID, existing.RuleID); err != nil {
+			return err
+		}
+		if _, _, err := l.client.LoadBalancer.CreateForwardingRule(ctx, lbID, &desired); err != nil { //nolint:bodyclose
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *loadbalancers) deleteServiceForwardingRules(ctx context.Context, lbID string, service *v1.Service) error {
+	desiredRules, err := buildForwardingRules(service)
+	if err != nil {
+		return err
+	}
+
+	serviceRuleFrontends := map[string]struct{}{}
+	for _, rule := range desiredRules {
+		serviceRuleFrontends[forwardingRuleFrontendKey(rule)] = struct{}{}
+	}
+
+	existingRules, err := l.listForwardingRules(ctx, lbID)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range existingRules {
+		if _, ok := serviceRuleFrontends[forwardingRuleFrontendKey(rule)]; !ok {
+			continue
+		}
+
+		if err := l.client.LoadBalancer.DeleteForwardingRule(ctx, lbID, rule.RuleID); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (l *loadbalancers) listForwardingRules(ctx context.Context, lbID string) ([]govultr.ForwardingRule, error) {
+	listOptions := &govultr.ListOptions{PerPage: 25}
+	var rules []govultr.ForwardingRule
+
+	for {
+		pageRules, meta, resp, err := l.client.LoadBalancer.ListForwardingRules(ctx, lbID, listOptions)
+		if resp != nil {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				return nil, closeErr
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		rules = append(rules, pageRules...)
+		if meta == nil || meta.Links == nil || meta.Links.Next == "" {
+			break
+		}
+		listOptions.Cursor = meta.Links.Next
+	}
+
+	return rules, nil
+}
+
+func forwardingRuleFrontendKey(rule govultr.ForwardingRule) string {
+	return fmt.Sprintf("%s/%d", strings.ToLower(rule.FrontendProtocol), rule.FrontendPort)
+}
+
+func forwardingRulesEqual(a, b govultr.ForwardingRule) bool {
+	return strings.EqualFold(a.FrontendProtocol, b.FrontendProtocol) &&
+		a.FrontendPort == b.FrontendPort &&
+		strings.EqualFold(a.BackendProtocol, b.BackendProtocol) &&
+		a.BackendPort == b.BackendPort
+}
+
+func (l *loadbalancers) sharedLoadBalancerStillReferenced(ctx context.Context, service *v1.Service, lbID string) (bool, error) {
+	label := service.Annotations[annoVultrLoadBalancerLabel]
+	if err := l.GetKubeClient(); err != nil {
+		return false, fmt.Errorf("failed to get kubeclient: %s", err)
+	}
+
+	services, err := l.kubeClient.CoreV1().Services(metav1.NamespaceAll).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to list services referencing shared load balancer label %q: %s", label, err)
+	}
+
+	for i := range services.Items {
+		candidate := &services.Items[i]
+		if sameService(candidate, service) {
+			continue
+		}
+
+		if candidate.Annotations[annoVultrLoadBalancerLabel] == label {
+			return true, nil
+		}
+
+		if candidate.Annotations[annoVultrLoadBalancerID] == lbID && candidate.Annotations[annoVultrLoadBalancerLabel] != "" {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func sameService(a, b *v1.Service) bool {
+	if a.UID != "" && b.UID != "" {
+		return a.UID == b.UID
+	}
+
+	return a.Namespace == b.Namespace && a.Name == b.Name
 }
 
 func (l *loadbalancers) createNewLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {


### PR DESCRIPTION
This pull request introduces significant improvements to the handling of shared load balancers in the Vultr cloud provider integration, particularly focusing on the management and reconciliation of forwarding rules when multiple Kubernetes services reference the same load balancer. It also enhances test coverage for these scenarios and improves the fake client implementation to support more realistic testing.

**Shared Load Balancer Forwarding Rule Management:**

* Added logic to detect when a service is using a shared load balancer label and, in such cases, omits forwarding rules from the main update request and instead reconciles forwarding rules separately via the new `reconcileSharedForwardingRules` method. This ensures that only the correct rules are present for each service sharing the load balancer. [[1]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38R288-R302) [[2]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38R334-R480)
* When deleting a service, the code now checks if the shared load balancer is still referenced by other services. If so, it only deletes the forwarding rules related to the service being removed, and deletes the load balancer itself only when there are no remaining references. [[1]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38R315-R325) [[2]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38R334-R480)

**Test Enhancements:**

* Added comprehensive tests to verify correct behavior when updating and deleting shared load balancers, ensuring only the relevant forwarding rules are created or deleted, and the load balancer is only removed when no services reference it.

**Fake Client Improvements:**

* Improved the `fakeLB` struct and related methods to track created, updated, and deleted forwarding rules and load balancer state, enabling more accurate and meaningful unit tests. [[1]](diffhunk://#diff-334b363ea2dffe1775489d55f9127228fe9e7b640dcb4eb1272eaf028ecf97a1R244-R260) [[2]](diffhunk://#diff-334b363ea2dffe1775489d55f9127228fe9e7b640dcb4eb1272eaf028ecf97a1L264-R284) [[3]](diffhunk://#diff-334b363ea2dffe1775489d55f9127228fe9e7b640dcb4eb1272eaf028ecf97a1L303-R319) [[4]](diffhunk://#diff-334b363ea2dffe1775489d55f9127228fe9e7b640dcb4eb1272eaf028ecf97a1L313-R344)

**Utility and Helper Functions:**

* Introduced several helper functions for rule comparison, service identity, and forwarding rule key generation to support the new logic and improve code clarity.

**Test Imports:**

* Added necessary imports to support new test cases and utilities.

Implements #346 