### PR TITLE
add firewall rules configmap

### DIFF
--- a/docs/load-balancers.md
+++ b/docs/load-balancers.md
@@ -32,6 +32,7 @@ The annotations are listed below. Please note that all annotations listed below 
 | `sticky-session-enabled`           | `on`, `off`                       | `off`                                                    | Enables Sticky Sessions. If enabled you must provide `sticky-session-cookie-name`                                                                                                                                |
 | `sticky-session-cookie-name"`      | string                            |                                                          | Name of sticky session                                                                                                                                                                                           |
 | `firewall-rules`                   | string                            |                                                          | This is used to let you define your firewall rules. They must be supplied with "ip-with-with-subnet,port" format with `;` breaking up firewall rules. Example: `0.0.0.0/0,80;0.0.0.0/0,90`                       |
+| `firewall-rules-cm`                | string                            |                                                          | Name of a ConfigMap in the Service namespace containing firewall rules YAML in the `firewallRules` key. If both firewall rule annotations are set, this ConfigMap annotation is used.                              |
 | ~~`private-network`~~ (deprecated) | ~~`true` or `false`~~             | ~~`false`~~                                              | **Deprecated Please use vpc**. ~~This is used to attach your load balancer to a private network. If `true` the CCM will pull the `private_network_id` that is attached to the node that the CCM is running on.~~ |
 | `vpc`                              | `true` or `false`                 | `false`                                                  | This is used to attach your load balancer to a private network. If `true` the CCM will pull the `vpc_id` that is attached to the node that the CCM is running on.                                                |
 | `node-count`                       | int                               | 1                                                        | Number of LoadBalancer nodes to have. Only odd numbers are supported.                                                                                                                                            |
@@ -39,6 +40,25 @@ The annotations are listed below. Please note that all annotations listed below 
 | `label`                            | string                            |                                                          | Custom label for the Vultr Loadbalancer rather than the default generated name                                                                                                                                   |
 | `hostname`                         | string                            |                                                          | Custom domain to be used for the load balancer. Ex: `example.vultr.com`
 | `timeout`                          | int                               | `600`                                                    | Load balancer connection timeout (in seconds)
+
+### Firewall Rules ConfigMap
+
+Use `firewall-rules-cm` when firewall rules are too large for a Service annotation. The ConfigMap must be in the same namespace as the Service and must contain a `firewallRules` key with YAML grouped by IP type:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: lb-firewall-rules
+data:
+  firewallRules: |
+    v4:
+      - source: 0.0.0.0/0
+        port: 80
+    v6:
+      - source: "::/0"
+        port: 80
+```
 
 
 ## Using UDP

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/pflag v1.0.10
 	github.com/vultr/govultr/v3 v3.28.1
 	github.com/vultr/metadata v1.1.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/oauth2 v0.36.0
 	k8s.io/api v0.35.2
 	k8s.io/apimachinery v0.35.2
@@ -25,7 +26,6 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect

--- a/vultr/loadbalancer_test.go
+++ b/vultr/loadbalancer_test.go
@@ -209,6 +209,63 @@ func TestLoadbalancers_UpdateLoadBalancer(t *testing.T) {
 	}
 }
 
+func TestLoadbalancers_BuildLoadBalancerRequest_FirewallRulesConfigMap(t *testing.T) {
+	lb := &loadbalancers{
+		client: &govultr.Client{LoadBalancer: &fakeLB{}},
+		zone:   "ewr",
+		kubeClient: fake.NewClientset(&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "lb-firewall-rules",
+				Namespace: v1.NamespaceDefault,
+			},
+			Data: map[string]string{
+				firewallRulesCMKey: "v4:\n- source: 192.168.1.1/16\n  port: 80\nv6:\n- source: cloudflare\n  port: 443\n",
+			},
+		}),
+	}
+
+	svc := &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "lb-name",
+			Namespace: v1.NamespaceDefault,
+			UID:       "lb-name",
+			Annotations: map[string]string{
+				annoVultrFirewallRules:   "10.0.0.0/8,80",
+				annoVultrFirewallRulesCM: "lb-firewall-rules",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{
+					Name:     "test",
+					Protocol: "TCP",
+					Port:     int32(443),
+					NodePort: int32(30443),
+				},
+			},
+		},
+	}
+	nodes := []*v1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "node1"},
+			Spec:       v1.NodeSpec{ProviderID: "vultr://123"},
+		},
+	}
+
+	req, err := lb.buildLoadBalancerRequest(context.Background(), svc, nodes)
+	if err != nil {
+		t.Fatalf("expected nil got %s", err.Error())
+	}
+
+	expected := []govultr.LBFirewallRule{
+		{Source: "192.168.1.1/16", IPType: "v4", Port: 80},
+		{Source: "cloudflare", IPType: "v6", Port: 443},
+	}
+	if !reflect.DeepEqual(req.FirewallRules, expected) {
+		t.Fatalf("expected %+v got %+v", expected, req.FirewallRules)
+	}
+}
+
 func TestLoadbalancers_EnsureLoadBalancerDeleted(t *testing.T) {
 	client := newFakeClient()
 	lb := newLoadbalancers(client, "1")

--- a/vultr/loadbalancers.go
+++ b/vultr/loadbalancers.go
@@ -14,6 +14,7 @@ import (
 	"github.com/asaskevich/govalidator"
 	"github.com/vultr/govultr/v3"
 	"github.com/vultr/metadata"
+	"go.yaml.in/yaml/v3"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -82,9 +83,11 @@ const (
 	annoVultrStickySessionEnabled    = "service.beta.kubernetes.io/vultr-loadbalancer-sticky-session-enabled"
 	annoVultrStickySessionCookieName = "service.beta.kubernetes.io/vultr-loadbalancer-sticky-session-cookie-name"
 
-	annoVultrFirewallRules  = "service.beta.kubernetes.io/vultr-loadbalancer-firewall-rules"
-	annoVultrPrivateNetwork = "service.beta.kubernetes.io/vultr-loadbalancer-private-network"
-	annoVultrVPC            = "service.beta.kubernetes.io/vultr-loadbalancer-vpc"
+	annoVultrFirewallRules   = "service.beta.kubernetes.io/vultr-loadbalancer-firewall-rules"
+	annoVultrFirewallRulesCM = "service.beta.kubernetes.io/vultr-loadbalancer-firewall-rules-cm"
+	firewallRulesCMKey       = "firewallRules"
+	annoVultrPrivateNetwork  = "service.beta.kubernetes.io/vultr-loadbalancer-private-network"
+	annoVultrVPC             = "service.beta.kubernetes.io/vultr-loadbalancer-vpc"
 
 	annoVultrNodeCount = "service.beta.kubernetes.io/vultr-loadbalancer-node-count"
 
@@ -281,7 +284,7 @@ func (l *loadbalancers) updateLoadBalancerWithLB(ctx context.Context, _ string, 
 		}
 	}
 
-	lbReq, err := l.buildLoadBalancerRequest(service, nodes)
+	lbReq, err := l.buildLoadBalancerRequest(ctx, service, nodes)
 	if err != nil {
 		return fmt.Errorf("failed to create load balancer request: %s", err)
 	}
@@ -480,7 +483,7 @@ func sameService(a, b *v1.Service) bool {
 
 func (l *loadbalancers) createNewLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
 	klog.Infof("Load balancer for cluster %q doesn't exist, creating", clusterName)
-	lbReq, err := l.buildLoadBalancerRequest(service, nodes)
+	lbReq, err := l.buildLoadBalancerRequest(ctx, service, nodes)
 	if err != nil {
 		return nil, err
 	}
@@ -721,7 +724,7 @@ func (l *loadbalancers) findLoadBalancerByName(ctx context.Context, service *v1.
 	lbName := l.GetLoadBalancerName(ctx, "", service)
 	return l.lbByName(ctx, lbName)
 }
-func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v1.Node) (*govultr.LoadBalancerReq, error) {
+func (l *loadbalancers) buildLoadBalancerRequest(ctx context.Context, service *v1.Service, nodes []*v1.Node) (*govultr.LoadBalancerReq, error) {
 	stickySession, err := buildStickySession(service)
 	if err != nil {
 		return nil, err
@@ -769,7 +772,7 @@ func (l *loadbalancers) buildLoadBalancerRequest(service *v1.Service, nodes []*v
 		autoSSL = nil
 	}
 
-	firewallRules, err := buildFirewallRules(service)
+	firewallRules, err := l.buildFirewallRules(ctx, service)
 	if err != nil {
 		return nil, err
 	}
@@ -1302,8 +1305,12 @@ func getTimeout(service *v1.Service) (int, error) {
 	return timeout, nil
 }
 
-func buildFirewallRules(service *v1.Service) ([]govultr.LBFirewallRule, error) {
+func (l *loadbalancers) buildFirewallRules(ctx context.Context, service *v1.Service) ([]govultr.LBFirewallRule, error) {
 	lbFWRules := []govultr.LBFirewallRule{}
+	if _, ok := service.Annotations[annoVultrFirewallRulesCM]; ok {
+		return l.getFirewallRulesFromConfigMap(ctx, service)
+	}
+
 	fwRules := getFirewallRules(service)
 	if fwRules == "" {
 		return lbFWRules, nil
@@ -1350,6 +1357,93 @@ func getFirewallRules(service *v1.Service) string {
 	}
 
 	return fwRules
+}
+
+func (l *loadbalancers) getFirewallRulesFromConfigMap(ctx context.Context, service *v1.Service) ([]govultr.LBFirewallRule, error) {
+	cmName := strings.TrimSpace(service.Annotations[annoVultrFirewallRulesCM])
+	if cmName == "" {
+		return nil, fmt.Errorf("%s annotation must not be empty", annoVultrFirewallRulesCM)
+	}
+
+	if err := l.GetKubeClient(); err != nil {
+		return nil, err
+	}
+
+	cm, err := l.kubeClient.CoreV1().ConfigMaps(service.Namespace).Get(ctx, cmName, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	fwRulesYAML, ok := cm.Data[firewallRulesCMKey]
+	if !ok {
+		return nil, fmt.Errorf("configmap %s/%s is missing %q key", service.Namespace, cmName, firewallRulesCMKey)
+	}
+
+	var fwRulesConfig struct {
+		FirewallRules firewallRulesByIPType `yaml:"firewallRules"`
+	}
+	if err := yaml.Unmarshal([]byte(fwRulesYAML), &fwRulesConfig.FirewallRules); err != nil {
+		return nil, fmt.Errorf("configmap %s/%s has invalid firewall rules YAML: %w", service.Namespace, cmName, err)
+	}
+
+	if len(fwRulesConfig.FirewallRules.V4) == 0 && len(fwRulesConfig.FirewallRules.V6) == 0 {
+		if err := yaml.Unmarshal([]byte(fwRulesYAML), &fwRulesConfig); err != nil {
+			return nil, fmt.Errorf("configmap %s/%s has invalid firewall rules YAML: %w", service.Namespace, cmName, err)
+		}
+	}
+
+	fwRules := make([]govultr.LBFirewallRule, 0, len(fwRulesConfig.FirewallRules.V4)+len(fwRulesConfig.FirewallRules.V6))
+	for _, fwRule := range fwRulesConfig.FirewallRules.V4 {
+		fwRule.IPType = "v4"
+		if err := validateFirewallRule(fwRule); err != nil {
+			return nil, err
+		}
+		fwRules = append(fwRules, fwRule)
+	}
+	for _, fwRule := range fwRulesConfig.FirewallRules.V6 {
+		fwRule.IPType = "v6"
+		if err := validateFirewallRule(fwRule); err != nil {
+			return nil, err
+		}
+		fwRules = append(fwRules, fwRule)
+	}
+
+	return fwRules, nil
+}
+
+type firewallRulesByIPType struct {
+	V4 []govultr.LBFirewallRule `yaml:"v4"`
+	V6 []govultr.LBFirewallRule `yaml:"v6"`
+}
+
+func validateFirewallRule(fwRule govultr.LBFirewallRule) error {
+	if fwRule.Source == "" {
+		return fmt.Errorf("loadbalancer fw rules : source is required")
+	}
+
+	if fwRule.Source != "cloudflare" {
+		ip, _, err := net.ParseCIDR(fwRule.Source)
+		if err != nil {
+			return fmt.Errorf("loadbalancer fw rules : source %s is invalid", fwRule.Source)
+		}
+
+		if fwRule.IPType == "v4" && ip.To4() == nil {
+			return fmt.Errorf("loadbalancer fw rules : source %s is not a v4 CIDR", fwRule.Source)
+		}
+		if fwRule.IPType == "v6" && ip.To4() != nil {
+			return fmt.Errorf("loadbalancer fw rules : source %s is not a v6 CIDR", fwRule.Source)
+		}
+	}
+
+	if fwRule.IPType != "v4" && fwRule.IPType != "v6" {
+		return fmt.Errorf("loadbalancer fw rules : ip_type %s is invalid", fwRule.IPType)
+	}
+
+	if fwRule.Port == 0 {
+		return fmt.Errorf("loadbalancer fw rules : port is required")
+	}
+
+	return nil
 }
 
 func getVPC(service *v1.Service) (string, error) {


### PR DESCRIPTION
This pull request introduces support for specifying load balancer firewall rules via a Kubernetes ConfigMap, making it possible to manage large or complex firewall rule sets that exceed annotation size limits. It adds a new annotation to reference the ConfigMap, updates the documentation with usage instructions, and implements and tests the logic for loading and validating firewall rules from the ConfigMap.

**New Firewall Rules via ConfigMap:**

* Added support for the `service.beta.kubernetes.io/vultr-loadbalancer-firewall-rules-cm` annotation, allowing firewall rules to be specified in a ConfigMap instead of directly in Service annotations. The controller will use the ConfigMap if both annotation types are present. (`vultr/loadbalancers.go`, `docs/load-balancers.md`) [[1]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38R87-R88) [[2]](diffhunk://#diff-30e6e5a6475462c7f8a925a3397362e3c6481aa2f057693e21cfda50355d6661R35)

* Implemented `getFirewallRulesFromConfigMap`, which loads and validates firewall rules from the referenced ConfigMap, supporting both IPv4 and IPv6 rules, and handling YAML parsing and validation. (`vultr/loadbalancers.go`)

* Updated the controller logic to use the new ConfigMap-based rules when present, and refactored function signatures to pass context where needed. (`vultr/loadbalancers.go`) [[1]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38L284-R287) [[2]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38L483-R486) [[3]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38L724-R727) [[4]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38L772-R775) [[5]](diffhunk://#diff-806ec8d8049378ad073c6dc420075775d07a71f42b88d9bb7fe87cbaf63b6a38L1305-R1313)

**Documentation:**

* Added documentation for the new annotation and provided an example ConfigMap YAML for specifying firewall rules by IP type. (`docs/load-balancers.md`)

**Testing:**

* Added a unit test to verify that firewall rules are correctly loaded and parsed from a ConfigMap when the new annotation is set. (`vultr/loadbalancer_test.go`)

**Dependency Updates:**

* Updated dependencies to include `go.yaml.in/yaml/v3` for YAML parsing. (`go.mod`) [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R10) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L28)